### PR TITLE
hotfix pathing for associated media with sounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,4 @@ pid.txt
 dump.rdb
 nohup.out
 *.env
+media/

--- a/app/modules/aliases.py
+++ b/app/modules/aliases.py
@@ -6,10 +6,11 @@ from .app_config import config
 from .database import GetDB
 
 class Sound:
-    def __init__(self, sound_id = None, path = None,  media = None):
+    def __init__(self, sound_id = None, path = None,  media = None, media_parent_folder = None):
         self.sound_id = sound_id
         self.path = path
         self.media = media 
+        self.media_parent_folder = media_parent_folder
 
 class SoundsInfo:
     """
@@ -37,9 +38,12 @@ class SoundsInfo:
                     db = GetDB(config.database_path)
                     db.set_row_factory(lambda cursor, row: row[0:2])
                     media = db.cursor.execute(f"SELECT image_id, folder FROM images WHERE sound_id=\"{sound_id}\"").fetchone()
+                    media_parent_folder = None
+                    media_name = None
                     if media is not None:
-                        media = f"{media[1]}/{media[0]}"
-                    sound_object = Sound(sound_id = sound_id, path = path, media = media)
+                        media_name = f"{media[0]}"
+                        media_parent_folder = f"{media[1]}"
+                    sound_object = Sound(sound_id = sound_id, path = path, media = media_name, media_parent_folder = media_parent_folder)
                     alias_dict[sound_object.sound_id] = sound_object
                     db.close()
 

--- a/app/modules/player.py
+++ b/app/modules/player.py
@@ -20,7 +20,11 @@ class Player:
 
         try:
             if sound_object.media is not None:
-                file = discord.File(str(f"{config.media_path}/{sound_object.media}"))
+                media_path_dict = {
+                    "images": config.images_path,
+                    "gifs": config.gifs_path
+                }
+                file = discord.File(str(f"{media_path_dict[sound_object.media_parent_folder]}/{sound_object.media}"))
                 await ctx.send(file=file, delete_after=10)
         except:
             pass


### PR DESCRIPTION
hotfix images and gifs to be determined by specific parent folder instead of parent `media` folder. 