### PR TITLE
Enable folders for entry sound

### DIFF
--- a/app/db/sounds.sql
+++ b/app/db/sounds.sql
@@ -20,7 +20,7 @@ FOREIGN KEY ([author_id]) REFERENCES "authors" ([author_id]) ON DELETE NO ACTION
 CREATE TABLE IF NOT EXISTS "entrance"(
 [sound_id] NVARCHAR(220) NOT NULL,
 [user_id] INTEGER NOT NULL,
-[last_seen] NVARCHAR(80),
+[content_type] NVARCHAR(220) DEFAULT sound NOT NULL,
 FOREIGN KEY ([sound_id]) REFERENCES "sounds" ([sound_id]) ON DELETE NO ACTION ON UPDATE NO ACTION
 );
 CREATE TABLE IF NOT EXISTS "quicksounds"
@@ -34,6 +34,6 @@ CREATE TABLE IF NOT EXISTS "images"
 (
 [sound_id] NVARCHAR(220) NOT NULL,
 [image_id] NVARCHAR(256) NOT NULL,
-[folder]   NVARCHAR(220) NOT NULL,
+[folder] NVARCHAR(220),
 FOREIGN KEY ([sound_id]) REFERENCES "sounds" ([sound_id]) ON DELETE NO ACTION ON UPDATE NO ACTION
 );

--- a/app/modules/helper_functions.py
+++ b/app/modules/helper_functions.py
@@ -59,7 +59,7 @@ def checkGroup(group):
     Returns Boolean
     """
     db = GetDB(config.database_path)
-    data = db.cursor.execute(f"SELECT EXISTS(SELECT sound_id FROM sounds WHERE sound_id=\"{group}\"").fetchall()
+    data = db.cursor.execute(f"SELECT EXISTS(SELECT category_id FROM categories WHERE category_id=\"{group}\")").fetchall()
     db.close()
     for item in data:
         if item[0] == 1:


### PR DESCRIPTION
Summary
---------

- Update `entrance set` and `entrance info` command to support setting folders as entry sound. 
- Update `Entrance` cog to allow for playback of a direct soundpath or a random sound contained within a folder.
- Update database schema to support required columns used to determine if an entry sound is a folder or a sound.

This allows for a random sound from a folder to be played as an entry sound.
 
Notes
-------

All active production databases must be reconfigured using the following SQLite transaction below to support the proper column in the `entrance` table.

```sql
BEGIN TRANSACTION;
ALTER TABLE entrance DROP COLUMN [last_seen];
ALTER TABLE entrance ADD COLUMN [content_type] NVARCHAR(220) DEFAULT sound NOT NULL;
COMMIT;
```

See Also
--------
https://github.com/Jnathan0/doot-doot-wow/projects/3#card-88151160