### PR TITLE
remove redis worker calls to update playcounts

### DIFF
--- a/app/cogs/Player.py
+++ b/app/cogs/Player.py
@@ -29,12 +29,12 @@ class Player(commands.Cog, commands.Command):
             sound_id = sound_object.sound_id
 
             call_type = "random"
-            config.sounds_queue.enqueue(increment_playcount, sound_id)
+            increment_playcount(sound_id)
         else:
             sound_id = command
 
             call_type = "direct"
-            config.sounds_queue.enqueue(increment_playcount, sound_id)
+            increment_playcount(sound_id)
 
         await player.play(ctx, sound_object, reverse)
 
@@ -66,10 +66,10 @@ class Player(commands.Cog, commands.Command):
             file_path = random.choice(random_path)
             sound_id = file_path.sound_id
             random_path = file_path
-            config.sounds_queue.enqueue(increment_playcount, sound_id)
+            increment_playcount(sound_id)
         else:
             sound_id = random_path.sound_id
-            config.sounds_queue.enqueue(increment_playcount, sound_id)
+            increment_playcount(sound_id)
 
         msg = await ctx.send(format_markdown("Random sound: "+str(sound_id)))
         


### PR DESCRIPTION
remove redis worker calls to update playcounts

Change updating the playcount of a sound to direct calls to the database via function instead of using redis workers. 
Hopefully this is to resolve performance issues related to using redis workers on python, as a new worker process will fork the parent process causing app lockup for some time (depending on processing power and memory available) 