### PR TITLE
Use alpine for base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,4 @@ dump.rdb
 nohup.out
 *.env
 media/
+test-data/

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,20 +1,33 @@
-FROM python:3.8.12-bullseye
+FROM python:3.8-alpine as base
+FROM base AS builder
 
-RUN apt update
-RUN apt install sqlite3 -y
-RUN apt install ffmpeg -y
-RUN apt install net-tools -y
-RUN apt install nano -y 
-RUN apt install inetutils-ping -y
-
-# Install dumb-init for container init process 
-# See more at: https://github.com/Yelp/dumb-init
+RUN apk add git
+RUN apk add --no-cache --virtual .build-deps musl-dev linux-headers g++ gcc zlib-dev make python3-dev jpeg-dev musl-dev libffi-dev openssl-dev
+COPY /requirements.txt /
+RUN apk add curl
 RUN curl -sSfLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
 RUN chmod 755 /usr/bin/dumb-init
 
+RUN python3 -m venv env
+RUN source ./env/bin/activate && \
+    pip3 install wheel && \
+    pip3 install -r requirements.txt;
+
+FROM base
+
+COPY --from=builder /env /env
+COPY --from=builder /usr/bin /usr/bin
+COPY --from=builder /usr/lib /usr/lib
+
+RUN apk update && apk upgrade
+RUN apk add --no-cache sqlite==3.45.3-r1
+RUN apk add ffmpeg==6.1.1-r8 
+RUN apk add net-tools==2.10-r3
+RUN apk add nano==8.0-r0
+RUN apk add iputils==20240117-r0
+
 ADD ./ /doot-doot/
 WORKDIR /doot-doot
-RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/bin/bash", "./init-app.sh"]
+CMD ["/bin/sh", "./init-app.sh"]

--- a/app/cogs/Entrance.py
+++ b/app/cogs/Entrance.py
@@ -65,7 +65,7 @@ class Entrance(commands.Cog):
             await asyncio.sleep(.7) # Let slow client connections get their ears open before we connect and play sounds
 
             vc = await channel.connect()
-            vc.play(discord.FFmpegPCMAudio(filepath))
+            vc.play(discord.FFmpegOpusAudio(filepath))
             with audioread.audio_open(filepath) as f:
                 #Start Playing
                 while vc.is_playing():

--- a/app/init-app.sh
+++ b/app/init-app.sh
@@ -2,10 +2,13 @@
 
 set -exo pipefail
 
-nohup /usr/local/bin/rqscheduler > scheduler.log &
+
+nohup /env/bin/rqscheduler > scheduler.log &
 nohup rqworker --with-scheduler metadata --name metadata > metadata_worker.log &
 nohup rqworker --with-scheduler generic_worker --name generic_worker > generic_worker.log &
 nohup rqworker plays --name plays > plays_worker.log &
+
+source /env/bin/activate
 
 # run the app
 python3 main.py 

--- a/app/modules/player.py
+++ b/app/modules/player.py
@@ -57,19 +57,19 @@ class Player:
         # will do a rickroll instead of the desired sound
         random_chance = random.randint(1, 500)
         if random_chance == 1:
-            source = discord.FFmpegPCMAudio(f"{config.sounds_path}/rickroll.mp3")
+            source = discord.FFmpegOpusAudio(f"{config.sounds_path}/rickroll.mp3")
 
         else:
             try:
                 if reverse == True:
-                    source = discord.FFmpegPCMAudio(sound_object.path, options='-af areverse')
-                    # source = discord.FFmpegPCMAudio(self.filename, options='-af acrusher=1:.45:52:0:log')
-                    # source = discord.FFmpegPCMAudio(self.filename, options='-af equalizer=f=50:width_type=o:width=2:g=20') bass boost ear rape 
-                    # source = discord.FFmpegPCMAudio(self.filename, options='-af areverse') reverse 
+                    source = discord.FFmpegOpusAudio(sound_object.path, options='-af areverse')
+                    # source = discord.FFmpegOpusAudio(self.filename, options='-af acrusher=1:.45:52:0:log')
+                    # source = discord.FFmpegOpusAudio(self.filename, options='-af equalizer=f=50:width_type=o:width=2:g=20') bass boost ear rape 
+                    # source = discord.FFmpegOpusAudio(self.filename, options='-af areverse') reverse 
                 else:
-                    source = discord.FFmpegPCMAudio(sound_object.path)
+                    source = discord.FFmpegOpusAudio(sound_object.path)
 
-                # source = discord.FFmpegPCMAudio(filename, options='-af areverse')
+                # source = discord.FFmpegOpusAudio(filename, options='-af areverse')
 
             # edge case: missing file error
             except FileNotFoundError:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -28,8 +28,8 @@ import-expression==1.1.4
 Jinja2==3.0.1
 jishaku==1.19.1.200
 MarkupSafe==2.0.1
-matplotlib==3.8.2
-pandas==2.1.4 
+matplotlib==3.7.5 
+pandas==2.0.3
 psutil==5.9.0
 pycparser==2.20
 PyMeeus==0.5.11


### PR DESCRIPTION
Use alpine for base image

Summary
----------
Use alpine base for app-image to reduce overall image size

Acceptance Criteria:
-----
- Libraries are migrated to their apk equivs.
- App python env is built in a virtual env and transferred into the final image
- ffmpeg subprocesses can run
