### PR TITLE
Install poetry at runtime and put venv bin on PATH

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -24,6 +24,8 @@ ADD ./ /doot-doot/
 WORKDIR /doot-doot
 COPY --from=builder /.venv ./.venv
 
+RUN pip install poetry
+ENV PATH="/doot-doot/.venv/bin:$PATH"
 ENV TZ="UTC"
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
poetry was only installed in the builder stage. Removing the broad COPY --from=builder /usr/local/... blocks (done in the Alpine→slim migration) meant poetry was no longer present at runtime, breaking init-app.sh's `poetry run python3 main.py` call.

Also puts the venv bin on PATH so rqworker and other installed CLI tools resolve without absolute paths.