### PR TITLE
Feature/test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help env install lock build build-bot up down restart rebuild clean clean-logs
+PYTEST ?= $(shell command -v $(CURDIR)/app/env/bin/pytest 2>/dev/null || command -v pytest)
+
+.PHONY: help env install lock build build-bot up down restart rebuild clean clean-logs test
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n\nTargets:\n"} \
@@ -14,6 +16,9 @@ install: ## Install Python dependencies via Poetry
 
 lock: ## Re-solve and update poetry.lock
 	cd app && poetry lock
+
+test: ## Run the pytest suite (override with PYTEST=... if needed)
+	cd app && $(PYTEST) tests/ -v
 
 # ── Docker ─────────────────────────────────────────────────────────────────────
 

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -71,3 +71,12 @@ pyyaml = "6.0.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.dev-dependencies]
+pytest = "*"
+pytest-asyncio = "*"
+pytest-mock = "*"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["."]

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -80,3 +80,6 @@ pytest-mock = "*"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 pythonpath = ["."]
+filterwarnings = [
+    "ignore:'audioop' is deprecated:DeprecationWarning",
+]

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+# ---------------------------------------------------------------------------
+# Block dangerous module-level side effects before any app code is imported.
+#
+# modules/app_config.py ends with:   config = AppConfig()  (Redis + fs checks)
+# modules/aliases.py ends with:      sounds = SoundsInfo(config.sounds_path)  (os.scandir)
+#
+# Strategy:
+#   1. Inject a fake `modules.app_config` stub into sys.modules so that
+#      `from .app_config import config` inside aliases.py gets our mock.
+#   2. Stub every other sub-module that __init__.py re-exports so that
+#      importing `modules` never reaches real Redis/filesystem code.
+#   3. Temporarily replace os.scandir with a no-op so SoundsInfo.__init__
+#      completes without touching the filesystem.
+#   4. Import only what tests actually need (Sound, SoundsInfo) directly from
+#      the real aliases module, then restore os.scandir.
+# ---------------------------------------------------------------------------
+
+# Step 1 – build a concrete mock config
+_mock_config = MagicMock()
+_mock_config.prefix = "!"
+_mock_config.sub_cmd_sep = " "
+_mock_config.reverse_char = "-"
+_mock_config.sounds_path = "/sounds"
+_mock_config.gifs_path = "/gifs"
+_mock_config.images_path = "/images"
+_mock_config.database_path = "/db/sounds.db"
+_mock_config.media_duration_limit = 180
+_mock_config.worker_queue = MagicMock()
+
+# Step 2 – inject stubs for every sub-module that carries side effects
+_app_config_stub = MagicMock()
+_app_config_stub.config = _mock_config
+
+sys.modules.setdefault("modules.app_config", _app_config_stub)
+
+for _mod_name in (
+    "modules.errors",
+    "modules.metadata",
+    "modules.database",
+    "modules.redisworkers",
+    "modules.quicksounds",
+    "modules.imgprocessing",
+    "modules.command_help",
+    "modules.menus",
+    "modules.media",
+):
+    sys.modules.setdefault(_mod_name, MagicMock())
+
+# Step 3/4 – import Sound and SoundsInfo with os.scandir patched out.
+# os.scandir is used as a context manager (`with os.scandir(...) as it:`), so
+# the replacement must support __enter__/__exit__ as well as __iter__.
+class _EmptyScandir:
+    def __enter__(self):
+        return iter([])
+    def __exit__(self, *_):
+        return False
+    def __iter__(self):
+        return iter([])
+
+_real_scandir = os.scandir
+os.scandir = lambda path: _EmptyScandir()
+
+from modules.aliases import Sound, SoundsInfo  # noqa: E402
+
+os.scandir = _real_scandir
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_ctx():
+    """Fake discord.py Context object."""
+    ctx = MagicMock()
+
+    # guild voice state – no existing voice client
+    ctx.message.guild.voice_client = None
+
+    # author identity
+    ctx.message.author.id = 12345
+    ctx.message.content = "!test_sound"
+
+    # voice channel – connect() returns a voice_client with play/disconnect
+    voice_client = MagicMock()
+
+    def _play(source, *, after=None):
+        if after is not None:
+            after(None)
+
+    voice_client.play = MagicMock(side_effect=_play)
+    voice_client.disconnect = AsyncMock()
+
+    voice_channel = MagicMock()
+    voice_channel.connect = AsyncMock(return_value=voice_client)
+
+    ctx.author.voice.channel = voice_channel
+
+    # async helpers
+    ctx.send = AsyncMock()
+    ctx.message.delete = AsyncMock()
+
+    return ctx
+
+
+@pytest.fixture
+def mock_sound():
+    """A plain Sound with no media attachment."""
+    return Sound(sound_id="test_sound", path="/sounds/test_sound.mp3", media=None)
+
+
+@pytest.fixture
+def mock_sound_with_media():
+    """A Sound that references an image."""
+    return Sound(
+        sound_id="test_sound",
+        path="/sounds/test_sound.mp3",
+        media="image.png",
+        media_parent_folder="images",
+    )
+
+
+@pytest.fixture
+def mock_sounds_info():
+    """A MagicMock standing in for a real SoundsInfo instance."""
+    info = MagicMock()
+    sound = Sound(sound_id="test_sound", path="/sounds/test_sound.mp3")
+    category_sound = Sound(sound_id="category test", path="/sounds/category/test.mp3")
+    info.alias_dict = {"test_sound": sound, "category": [category_sound]}
+    info.aliases = ["test_sound", "category"]
+    return info

--- a/app/tests/test_aliases.py
+++ b/app/tests/test_aliases.py
@@ -1,0 +1,193 @@
+import pytest
+import os
+from unittest.mock import MagicMock, patch, call
+from modules.aliases import Sound, SoundsInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build fake DirEntry-like mocks and context manager wrappers
+# ---------------------------------------------------------------------------
+
+def make_file_entry(name, path):
+    entry = MagicMock()
+    entry.is_file.return_value = True
+    entry.is_dir.return_value = False
+    entry.name = name
+    entry.path = path
+    return entry
+
+
+def make_dir_entry(name, path):
+    entry = MagicMock()
+    entry.is_file.return_value = False
+    entry.is_dir.return_value = True
+    entry.name = name
+    entry.path = path
+    return entry
+
+
+def scandir_returning(entries):
+    ctx = MagicMock()
+    ctx.__enter__.return_value = iter(entries)
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Sound tests
+# ---------------------------------------------------------------------------
+
+def test_sound_with_all_args():
+    s = Sound(sound_id="s", path="/p", media="img.png", media_parent_folder="images")
+    assert s.sound_id == "s"
+    assert s.path == "/p"
+    assert s.media == "img.png"
+    assert s.media_parent_folder == "images"
+
+
+def test_sound_defaults():
+    s = Sound()
+    assert s.sound_id is None
+    assert s.path is None
+    assert s.media is None
+    assert s.media_parent_folder is None
+
+
+# ---------------------------------------------------------------------------
+# SoundsInfo.getAliasInfo tests
+# ---------------------------------------------------------------------------
+
+def test_get_alias_info_flat_dir(mocker):
+    """Two flat file entries, no media — alias_dict has 2 Sound objects, category_list empty."""
+    file1 = make_file_entry("beep.mp3", "/sounds/beep.mp3")
+    file2 = make_file_entry("boop.mp3", "/sounds/boop.mp3")
+
+    mock_GetDB = mocker.patch("modules.aliases.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchone.return_value = None
+
+    mocker.patch("os.scandir", return_value=scandir_returning([file1, file2]))
+
+    si = SoundsInfo("/sounds")
+
+    assert len(si.alias_dict) == 2
+    assert "beep" in si.alias_dict
+    assert "boop" in si.alias_dict
+    assert isinstance(si.alias_dict["beep"], Sound)
+    assert isinstance(si.alias_dict["boop"], Sound)
+    assert si.category_list == []
+
+
+def test_get_alias_info_with_subdir(mocker):
+    """Root has 1 file + 1 dir; subdir has 2 files."""
+    root_file = make_file_entry("solo.mp3", "/sounds/solo.mp3")
+    subdir = make_dir_entry("effects", "/sounds/effects")
+
+    sub_file1 = make_file_entry("bang.mp3", "/sounds/effects/bang.mp3")
+    sub_file2 = make_file_entry("crash.mp3", "/sounds/effects/crash.mp3")
+
+    root_ctx = scandir_returning([root_file, subdir])
+    sub_ctx = scandir_returning([sub_file1, sub_file2])
+
+    mock_GetDB = mocker.patch("modules.aliases.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchone.return_value = None
+
+    mocker.patch("os.scandir", side_effect=[root_ctx, sub_ctx])
+
+    si = SoundsInfo("/sounds")
+
+    # flat sound
+    assert "solo" in si.alias_dict
+    assert isinstance(si.alias_dict["solo"], Sound)
+
+    # category key maps to a list of 2 Sounds
+    assert "effects" in si.alias_dict
+    assert isinstance(si.alias_dict["effects"], list)
+    assert len(si.alias_dict["effects"]) == 2
+
+    # sub-sounds are individually addressable too
+    assert "effects bang" in si.alias_dict
+    assert "effects crash" in si.alias_dict
+
+    assert si.category_list == ["effects"]
+
+
+def test_get_alias_info_empty_dir(mocker):
+    """Empty scandir — alias_dict and category_list are both empty."""
+    mock_GetDB = mocker.patch("modules.aliases.GetDB")
+
+    mocker.patch("os.scandir", return_value=scandir_returning([]))
+
+    si = SoundsInfo("/sounds")
+
+    assert si.alias_dict == {}
+    assert si.category_list == []
+
+
+def test_get_alias_info_sound_with_media(mocker):
+    """File entry where DB returns media row — Sound has media + media_parent_folder."""
+    file_entry = make_file_entry("bark.mp3", "/sounds/bark.mp3")
+
+    mock_GetDB = mocker.patch("modules.aliases.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    # DB returns (image_id, folder)
+    mock_db.cursor.execute.return_value.fetchone.return_value = ("img.png", "images")
+
+    mocker.patch("os.scandir", return_value=scandir_returning([file_entry]))
+
+    si = SoundsInfo("/sounds")
+
+    sound = si.alias_dict["bark"]
+    assert sound.media == "img.png"
+    assert sound.media_parent_folder == "images"
+
+
+def test_get_alias_info_sound_no_media(mocker):
+    """File entry where DB returns None — Sound has media=None."""
+    file_entry = make_file_entry("bark.mp3", "/sounds/bark.mp3")
+
+    mock_GetDB = mocker.patch("modules.aliases.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchone.return_value = None
+
+    mocker.patch("os.scandir", return_value=scandir_returning([file_entry]))
+
+    si = SoundsInfo("/sounds")
+
+    sound = si.alias_dict["bark"]
+    assert sound.media is None
+
+
+# ---------------------------------------------------------------------------
+# SoundsInfo.update_sounds test
+# ---------------------------------------------------------------------------
+
+def test_update_sounds(mocker):
+    """update_sounds refreshes alias_dict and aliases from a new scandir result."""
+    mock_GetDB = mocker.patch("modules.aliases.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchone.return_value = None
+
+    # First call (during __init__): empty dir
+    mock_scandir = mocker.patch("os.scandir", return_value=scandir_returning([]))
+    si = SoundsInfo("/sounds")
+
+    assert si.alias_dict == {}
+    assert si.aliases == []
+
+    # Second call (during update_sounds): one file
+    new_file = make_file_entry("ding.mp3", "/sounds/ding.mp3")
+    mock_scandir.return_value = scandir_returning([new_file])
+
+    si.update_sounds()
+
+    assert len(si.alias_dict) == 1
+    assert "ding" in si.alias_dict
+    assert len(si.aliases) == 1
+    assert "ding" in si.aliases

--- a/app/tests/test_helper_functions.py
+++ b/app/tests/test_helper_functions.py
@@ -1,0 +1,190 @@
+import pytest
+import datetime
+from unittest.mock import MagicMock, patch, call
+from modules.helper_functions import (
+    format_markdown,
+    get_last_thursday,
+    increment_playcount,
+    checkExists,
+    checkGroup,
+    isLoud,
+    checkExceedsDurationLimit,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure / no-mock tests
+# ---------------------------------------------------------------------------
+
+def test_format_markdown():
+    result = format_markdown("hello")
+    assert result == "```\nhello\n```"
+
+
+def test_get_last_thursday_is_thursday():
+    result = get_last_thursday()
+    # weekday() == 3 is Thursday
+    assert result.weekday() == 3
+
+
+def test_get_last_thursday_is_current_month():
+    result = get_last_thursday()
+    assert result.month == datetime.date.today().month
+
+
+# ---------------------------------------------------------------------------
+# increment_playcount — patch sqlite3.connect
+# ---------------------------------------------------------------------------
+
+def test_increment_playcount(mocker):
+    mock_connect = mocker.patch("modules.helper_functions.sqlite3.connect")
+    mock_conn = MagicMock()
+    mock_connect.return_value = mock_conn
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+
+    sound_id = "test_sound"
+    increment_playcount(sound_id)
+
+    # execute was called once; its argument should mention UPDATE and the sound id
+    mock_cursor.execute.assert_called_once()
+    sql_arg = mock_cursor.execute.call_args[0][0]
+    assert "UPDATE" in sql_arg
+    assert sound_id in sql_arg
+
+    mock_conn.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# checkExists — patch GetDB
+# ---------------------------------------------------------------------------
+
+def test_check_exists_true(mocker):
+    mock_GetDB = mocker.patch("modules.helper_functions.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchall.return_value = [(1,)]
+
+    result = checkExists("mygroup", "mysound")
+
+    assert result is True
+    mock_db.close.assert_called_once()
+
+
+def test_check_exists_false(mocker):
+    mock_GetDB = mocker.patch("modules.helper_functions.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchall.return_value = [(0,)]
+
+    result = checkExists("mygroup", "mysound")
+
+    assert result is False
+    mock_db.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# checkGroup — patch GetDB
+# ---------------------------------------------------------------------------
+
+def test_check_group_true(mocker):
+    mock_GetDB = mocker.patch("modules.helper_functions.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchall.return_value = [(1,)]
+
+    result = checkGroup("mygroup")
+
+    assert result is True
+    mock_db.close.assert_called_once()
+
+
+def test_check_group_false(mocker):
+    mock_GetDB = mocker.patch("modules.helper_functions.GetDB")
+    mock_db = MagicMock()
+    mock_GetDB.return_value = mock_db
+    mock_db.cursor.execute.return_value.fetchall.return_value = [(0,)]
+
+    result = checkGroup("mygroup")
+
+    assert result is False
+    mock_db.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# isLoud — patch ffmpeg
+# ---------------------------------------------------------------------------
+
+def test_is_loud_true(mocker):
+    mocker.patch("modules.helper_functions.ffmpeg.input", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.filter_", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.output", return_value=MagicMock())
+    mocker.patch(
+        "modules.helper_functions.ffmpeg.run",
+        return_value=(b"", b"mean_volume: -5.0 dB"),
+    )
+
+    result = isLoud("/sounds/loud.mp3")
+
+    assert result is True
+
+
+def test_is_loud_false(mocker):
+    mocker.patch("modules.helper_functions.ffmpeg.input", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.filter_", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.output", return_value=MagicMock())
+    mocker.patch(
+        "modules.helper_functions.ffmpeg.run",
+        return_value=(b"", b"mean_volume: -20.0 dB"),
+    )
+
+    result = isLoud("/sounds/quiet.mp3")
+
+    assert result is False
+
+
+def test_is_loud_ffmpeg_error(mocker):
+    mocker.patch("modules.helper_functions.ffmpeg.input", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.filter_", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.output", return_value=MagicMock())
+    mocker.patch(
+        "modules.helper_functions.ffmpeg.run",
+        return_value=(b"some error", b""),
+    )
+
+    with pytest.raises(Exception):
+        isLoud("/sounds/bad.mp3")
+
+
+# ---------------------------------------------------------------------------
+# checkExceedsDurationLimit — patch ffmpeg + config
+# ---------------------------------------------------------------------------
+
+def test_exceeds_duration_limit_true(mocker):
+    mocker.patch("modules.helper_functions.ffmpeg.input", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.output", return_value=MagicMock())
+    mocker.patch(
+        "modules.helper_functions.ffmpeg.run",
+        return_value=(b"", b"Duration: 00:04:00"),
+    )
+    # 240 seconds > 180 second limit configured in conftest mock_config
+    mocker.patch("modules.helper_functions.config.media_duration_limit", 180)
+
+    result = checkExceedsDurationLimit("/sounds/long.mp3")
+
+    assert result is True
+
+
+def test_exceeds_duration_limit_false(mocker):
+    mocker.patch("modules.helper_functions.ffmpeg.input", return_value=MagicMock())
+    mocker.patch("modules.helper_functions.ffmpeg.output", return_value=MagicMock())
+    mocker.patch(
+        "modules.helper_functions.ffmpeg.run",
+        return_value=(b"", b"Duration: 00:02:00"),
+    )
+    # 120 seconds < 180 second limit
+    mocker.patch("modules.helper_functions.config.media_duration_limit", 180)
+
+    result = checkExceedsDurationLimit("/sounds/short.mp3")
+
+    assert result is False

--- a/app/tests/test_player_cog.py
+++ b/app/tests/test_player_cog.py
@@ -1,0 +1,298 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+import cogs.Player as cog_module
+from cogs.Player import Player as PlayerCog
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_cog():
+    bot = MagicMock()
+    cog = PlayerCog(bot)
+    # discord.py's Command.__call__ only prepends `self.cog` when cog is set.
+    # Without add_cog(), we inject it manually so tests can call commands normally.
+    for cmd in cog.__cog_commands__:
+        cmd.cog = cog
+    return cog
+
+
+# ---------------------------------------------------------------------------
+# master_command tests
+# ---------------------------------------------------------------------------
+
+
+class TestMasterCommand:
+    async def test_master_command_direct_sound(self, mock_ctx, mock_sound, mocker):
+        """Direct alias -> player.play called with Sound and reverse=False; enqueue direct."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mock_inc = mocker.patch("cogs.Player.increment_playcount")
+        mock_enqueue = mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+
+        cog = make_cog()
+        await cog.master_command(mock_ctx)
+
+        mock_play.assert_called_once_with(mock_ctx, mock_sound, False)
+        mock_inc.assert_called_once_with("test_sound")
+        mock_enqueue.assert_called_once()
+        # enqueue(update_metadata, user_id, sound_id, call_type) — call_type is args[3]
+        args = mock_enqueue.call_args[0]
+        assert args[3] == "direct"
+
+    async def test_master_command_category_picks_randomly(self, mock_ctx, mock_sound, mocker):
+        """List alias -> secrets.choice picks a Sound; enqueue with call_type='random'."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mock_inc = mocker.patch("cogs.Player.increment_playcount")
+        mock_enqueue = mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+
+        sound1 = MagicMock()
+        sound1.sound_id = "test_sound"
+        sound2 = MagicMock()
+        sound2.sound_id = "test_sound_alt"
+        sound_list = [sound1, sound2]
+
+        cog_module.sounds.alias_dict = {"test_sound": sound_list}
+        mocker.patch("cogs.Player.secrets.choice", return_value=sound1)
+
+        cog = make_cog()
+        await cog.master_command(mock_ctx)
+
+        mock_play.assert_called_once_with(mock_ctx, sound1, False)
+        mock_inc.assert_called_once_with(sound1.sound_id)
+        args = mock_enqueue.call_args[0]
+        assert args[3] == "random"
+
+    async def test_master_command_already_in_voice_returns_early(self, mock_ctx, mock_sound, mocker):
+        """Existing voice client -> return immediately without playing."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+        mock_ctx.message.guild.voice_client = MagicMock()
+
+        cog = make_cog()
+        await cog.master_command(mock_ctx)
+
+        mock_play.assert_not_called()
+
+    async def test_master_command_reverse_suffix(self, mock_ctx, mock_sound, mocker):
+        """Content ending with reverse_char -> player.play called with reverse=True."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+        mock_ctx.message.content = "!test_sound -"
+
+        cog = make_cog()
+        await cog.master_command(mock_ctx)
+
+        mock_play.assert_called_once_with(mock_ctx, mock_sound, True)
+
+    async def test_master_command_no_reverse(self, mock_ctx, mock_sound, mocker):
+        """Normal content (no trailing reverse_char) -> player.play called with reverse=False."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+        mock_ctx.message.content = "!test_sound"
+
+        cog = make_cog()
+        await cog.master_command(mock_ctx)
+
+        mock_play.assert_called_once_with(mock_ctx, mock_sound, False)
+
+
+# ---------------------------------------------------------------------------
+# random command tests
+# ---------------------------------------------------------------------------
+
+
+class TestRandomCommand:
+    async def test_random_plays_direct_sound(self, mock_ctx, mock_sound, mocker):
+        """Single Sound in alias_dict -> player.play called; ctx.send includes sound_id; enqueue 'random'."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mocker.patch("cogs.Player.increment_playcount")
+        mock_enqueue = mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+        mocker.patch("cogs.Player.asyncio.sleep", new_callable=AsyncMock)
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+        mocker.patch("cogs.Player.secrets.choice", return_value="test_sound")
+
+        # ctx.send returns an AsyncMock; give its return value a delete method
+        msg_mock = AsyncMock()
+        mock_ctx.send.return_value = msg_mock
+
+        mock_ctx.message.content = "!random"
+
+        cog = make_cog()
+        await cog.random(mock_ctx)
+
+        mock_play.assert_called_once_with(mock_ctx, mock_sound, False)
+        mock_ctx.send.assert_called_once()
+        send_text = mock_ctx.send.call_args[0][0]
+        assert mock_sound.sound_id in send_text
+
+        # In random command, call_type is passed as a keyword argument
+        kwargs = mock_enqueue.call_args[1]
+        assert kwargs.get("call_type") == "random"
+
+    async def test_random_picks_from_category(self, mock_ctx, mocker):
+        """List value in alias_dict -> second secrets.choice picks from the list."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mock_inc = mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+        mocker.patch("cogs.Player.asyncio.sleep", new_callable=AsyncMock)
+
+        sound1 = MagicMock()
+        sound1.sound_id = "cat_sound"
+        sound_list = [sound1]
+
+        cog_module.sounds.alias_dict = {"category": sound_list}
+
+        # First call returns the key, second call returns the Sound from the list
+        choice_mock = mocker.patch(
+            "cogs.Player.secrets.choice",
+            side_effect=["category", sound1],
+        )
+
+        msg_mock = AsyncMock()
+        mock_ctx.send.return_value = msg_mock
+        mock_ctx.message.content = "!random"
+
+        cog = make_cog()
+        await cog.random(mock_ctx)
+
+        mock_play.assert_called_once_with(mock_ctx, sound1, False)
+        mock_inc.assert_called_once_with(sound1.sound_id)
+
+    async def test_random_deletes_calling_message(self, mock_ctx, mock_sound, mocker):
+        """ctx.message.delete is called before player.play."""
+        call_order = []
+
+        mock_ctx.message.delete = AsyncMock(side_effect=lambda: call_order.append("delete"))
+
+        async def _play(*args, **kwargs):
+            call_order.append("play")
+
+        mocker.patch("cogs.Player.player.play", side_effect=_play)
+        mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+        mocker.patch("cogs.Player.asyncio.sleep", new_callable=AsyncMock)
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+        mocker.patch("cogs.Player.secrets.choice", return_value="test_sound")
+
+        msg_mock = AsyncMock()
+        mock_ctx.send.return_value = msg_mock
+        mock_ctx.message.content = "!random"
+
+        cog = make_cog()
+        await cog.random(mock_ctx)
+
+        mock_ctx.message.delete.assert_called_once()
+        assert call_order.index("delete") < call_order.index("play")
+
+    async def test_random_cleanup_message_deleted_after_sleep(self, mock_ctx, mock_sound, mocker):
+        """The message sent by ctx.send is deleted after asyncio.sleep."""
+        mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+        mock_sleep = mocker.patch("cogs.Player.asyncio.sleep", new_callable=AsyncMock)
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+        mocker.patch("cogs.Player.secrets.choice", return_value="test_sound")
+
+        msg_mock = AsyncMock()
+        msg_mock.delete = AsyncMock()
+        mock_ctx.send.return_value = msg_mock
+        mock_ctx.message.content = "!random"
+
+        cog = make_cog()
+        await cog.random(mock_ctx)
+
+        mock_sleep.assert_called_once_with(10)
+        msg_mock.delete.assert_called_once()
+
+    async def test_random_already_in_voice_returns_early(self, mock_ctx, mock_sound, mocker):
+        """Existing voice client -> return after deleting message, without playing."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+        mocker.patch("cogs.Player.asyncio.sleep", new_callable=AsyncMock)
+
+        cog_module.sounds.alias_dict = {"test_sound": mock_sound}
+        mock_ctx.message.guild.voice_client = MagicMock()
+        mock_ctx.message.content = "!random"
+
+        cog = make_cog()
+        await cog.random(mock_ctx)
+
+        mock_play.assert_not_called()
+
+    async def test_random_reverse_suffix(self, mock_ctx, mock_sound, mocker):
+        """Content ending with reverse_char -> player.play called with reverse=True."""
+        mock_play = mocker.patch("cogs.Player.player.play", new_callable=AsyncMock)
+        mocker.patch("cogs.Player.increment_playcount")
+        mocker.patch.object(cog_module.config.worker_queue, "enqueue")
+        mocker.patch("cogs.Player.asyncio.sleep", new_callable=AsyncMock)
+
+        cog_module.sounds.alias_dict = {"random": mock_sound}
+        mocker.patch("cogs.Player.secrets.choice", return_value="random")
+
+        msg_mock = AsyncMock()
+        mock_ctx.send.return_value = msg_mock
+        mock_ctx.message.content = "!random -"
+
+        cog = make_cog()
+        await cog.random(mock_ctx)
+
+        mock_play.assert_called_once_with(mock_ctx, mock_sound, True)
+
+
+# ---------------------------------------------------------------------------
+# stop command tests
+# ---------------------------------------------------------------------------
+
+
+class TestStopCommand:
+    async def test_stop_in_voice_disconnects(self, mock_ctx):
+        """Active voice client -> disconnect is called."""
+        voice_client = AsyncMock()
+        mock_ctx.message.guild.voice_client = voice_client
+
+        cog = make_cog()
+        await cog.stop(mock_ctx)
+
+        voice_client.disconnect.assert_called_once()
+
+    async def test_stop_not_in_voice(self, mock_ctx):
+        """No voice client -> disconnect is never called."""
+        mock_ctx.message.guild.voice_client = None
+
+        cog = make_cog()
+        await cog.stop(mock_ctx)
+
+        # Nothing to assert on disconnect — just verify no AttributeError was raised
+        # and message.delete was still called (next test). Passes if no exception.
+
+    async def test_stop_always_deletes_message(self, mock_ctx):
+        """ctx.message.delete is called regardless of voice state."""
+        # Test with no voice client
+        mock_ctx.message.guild.voice_client = None
+        cog = make_cog()
+        await cog.stop(mock_ctx)
+        mock_ctx.message.delete.assert_called_once()
+
+        # Reset and test with active voice client
+        mock_ctx.message.delete.reset_mock()
+        mock_ctx.message.guild.voice_client = AsyncMock()
+        await cog.stop(mock_ctx)
+        mock_ctx.message.delete.assert_called_once()

--- a/app/tests/test_player_module.py
+++ b/app/tests/test_player_module.py
@@ -1,0 +1,245 @@
+import pytest
+import discord
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch, call
+import modules.player as player_module
+from modules.player import _make_source, _maybe_send_media, Player
+
+
+# ---------------------------------------------------------------------------
+# _make_source tests
+# ---------------------------------------------------------------------------
+
+
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+def test_make_source_normal(mock_ffmpeg, mock_randint, mock_sound):
+    """Non-rickroll, non-reverse: FFmpegOpusAudio called with sound path and '-vn'."""
+    _make_source(mock_sound, reverse=False)
+
+    mock_ffmpeg.assert_called_once_with(
+        mock_sound.path,
+        before_options="-nostdin -hide_banner -loglevel error",
+        options="-vn",
+    )
+
+
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+def test_make_source_reverse(mock_ffmpeg, mock_randint, mock_sound):
+    """Reverse flag: FFmpegOpusAudio called with sound path and opts containing 'areverse'."""
+    _make_source(mock_sound, reverse=True)
+
+    _, kwargs = mock_ffmpeg.call_args
+    assert mock_ffmpeg.call_args[0][0] == mock_sound.path
+    assert "areverse" in kwargs["options"]
+
+
+@patch("modules.player.random.randint", return_value=1)
+@patch("modules.player.discord.FFmpegOpusAudio")
+def test_make_source_rickroll(mock_ffmpeg, mock_randint, mock_sound):
+    """randint returns 1: FFmpegOpusAudio called with the rickroll path."""
+    _make_source(mock_sound, reverse=False)
+
+    args, _ = mock_ffmpeg.call_args
+    assert "rickroll.mp3" in args[0]
+
+
+# ---------------------------------------------------------------------------
+# _maybe_send_media tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("modules.player.discord.File")
+async def test_maybe_send_media_with_media(mock_file, mock_ctx, mock_sound_with_media):
+    """Sound with media: discord.File constructed and ctx.send called."""
+    await _maybe_send_media(mock_ctx, mock_sound_with_media)
+
+    mock_file.assert_called_once()
+    mock_ctx.send.assert_called_once()
+    _, kwargs = mock_ctx.send.call_args
+    assert kwargs.get("delete_after") == 10
+
+
+@pytest.mark.asyncio
+async def test_maybe_send_media_no_media(mock_ctx, mock_sound):
+    """Sound with no media: ctx.send is never called."""
+    await _maybe_send_media(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("modules.player.discord.File")
+async def test_maybe_send_media_exception_swallowed(mock_file, mock_ctx, mock_sound_with_media):
+    """Exception inside _maybe_send_media is swallowed — nothing propagates."""
+    mock_ctx.send.side_effect = Exception("fail")
+
+    # Should not raise
+    await _maybe_send_media(mock_ctx, mock_sound_with_media)
+
+
+# ---------------------------------------------------------------------------
+# Player.play tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_play_user_not_in_voice(mock_ctx, mock_sound):
+    """Author is not in a voice channel: send called with warning; connect never called."""
+    mock_ctx.author.voice = None
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "not in a voice channel" in mock_ctx.send.call_args[0][0]
+    mock_ctx.author.voice  # still None — connect was never set up, no need to assert separately
+
+
+@pytest.mark.asyncio
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio", side_effect=FileNotFoundError)
+async def test_play_file_not_found(mock_ffmpeg, mock_randint, mock_ctx, mock_sound):
+    """FFmpegOpusAudio raises FileNotFoundError: send called with file-not-found message."""
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "File Not Found" in mock_ctx.send.call_args[0][0]
+    mock_ctx.author.voice.channel.connect.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+async def test_play_forbidden_on_connect(mock_ffmpeg, mock_randint, mock_ctx, mock_sound):
+    """connect() raises discord.Forbidden: send called with 403 message."""
+    mock_ctx.author.voice.channel.connect.side_effect = discord.Forbidden(
+        MagicMock(), "Forbidden"
+    )
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "403 Forbidden" in mock_ctx.send.call_args[0][0]
+
+
+@pytest.mark.asyncio
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+async def test_play_timeout_on_connect(mock_ffmpeg, mock_randint, mock_ctx, mock_sound):
+    """connect() raises TimeoutError: send called with timeout message."""
+    mock_ctx.author.voice.channel.connect.side_effect = TimeoutError
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "Timeout" in mock_ctx.send.call_args[0][0]
+
+
+@pytest.mark.asyncio
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+async def test_play_client_exception_on_connect(mock_ffmpeg, mock_randint, mock_ctx, mock_sound):
+    """connect() raises discord.ClientException: send called with 'already playing' message."""
+    mock_ctx.author.voice.channel.connect.side_effect = discord.ClientException("busy")
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "already playing" in mock_ctx.send.call_args[0][0]
+
+
+@pytest.mark.asyncio
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+async def test_play_generic_exception_on_connect(mock_ffmpeg, mock_randint, mock_ctx, mock_sound):
+    """connect() raises a generic Exception: send called with generic error message."""
+    mock_ctx.author.voice.channel.connect.side_effect = Exception("boom")
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "error processing your request" in mock_ctx.send.call_args[0][0]
+
+
+@pytest.mark.asyncio
+@patch("modules.player.asyncio.create_task")
+@patch("modules.player.asyncio.get_running_loop")
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+async def test_play_forbidden_on_play(
+    mock_ffmpeg, mock_randint, mock_get_loop, mock_create_task, mock_ctx, mock_sound
+):
+    """voice_client.play raises discord.Forbidden: send called with permission error; create_task called for disconnect."""
+    voice_client = mock_ctx.author.voice.channel.connect.return_value
+    voice_client.play.side_effect = discord.Forbidden(MagicMock(), "Forbidden")
+
+    mock_loop = MagicMock()
+    mock_get_loop.return_value = mock_loop
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "issue playing a sound effect" in mock_ctx.send.call_args[0][0]
+    mock_create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("modules.player.asyncio.create_task")
+@patch("modules.player.asyncio.get_running_loop")
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+async def test_play_timeout_on_play(
+    mock_ffmpeg, mock_randint, mock_get_loop, mock_create_task, mock_ctx, mock_sound
+):
+    """voice_client.play raises TimeoutError: send called with timeout message; create_task called for disconnect."""
+    voice_client = mock_ctx.author.voice.channel.connect.return_value
+    voice_client.play.side_effect = TimeoutError
+
+    mock_loop = MagicMock()
+    mock_get_loop.return_value = mock_loop
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    mock_ctx.send.assert_called_once()
+    assert "Timeout" in mock_ctx.send.call_args[0][0]
+    mock_create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("modules.player.asyncio.create_task")
+@patch("modules.player.asyncio.get_running_loop")
+@patch("modules.player.random.randint", return_value=5)
+@patch("modules.player.discord.FFmpegOpusAudio")
+async def test_play_happy_path(
+    mock_ffmpeg, mock_randint, mock_get_loop, mock_create_task, mock_ctx, mock_sound
+):
+    """Full happy path: playback completes, disconnect task is scheduled via create_task."""
+    voice_client = mock_ctx.author.voice.channel.connect.return_value
+
+    # Make get_running_loop return a mock whose call_soon_threadsafe calls its argument
+    # immediately, so done.set() is invoked and done.wait() unblocks.
+    mock_loop = MagicMock()
+    mock_loop.call_soon_threadsafe.side_effect = lambda fn: fn()
+    mock_get_loop.return_value = mock_loop
+
+    p = Player()
+    await p.play(mock_ctx, mock_sound)
+
+    # play was invoked on the voice client
+    voice_client.play.assert_called_once()
+
+    # A disconnect task was scheduled after playback finished
+    mock_create_task.assert_called_once()
+
+    # No error messages were sent
+    mock_ctx.send.assert_not_called()

--- a/app/tests/test_player_module.py
+++ b/app/tests/test_player_module.py
@@ -170,7 +170,7 @@ async def test_play_generic_exception_on_connect(mock_ffmpeg, mock_randint, mock
 
 
 @pytest.mark.asyncio
-@patch("modules.player.asyncio.create_task")
+@patch("modules.player.asyncio.create_task", side_effect=lambda coro: coro.close())
 @patch("modules.player.asyncio.get_running_loop")
 @patch("modules.player.random.randint", return_value=5)
 @patch("modules.player.discord.FFmpegOpusAudio")
@@ -193,7 +193,7 @@ async def test_play_forbidden_on_play(
 
 
 @pytest.mark.asyncio
-@patch("modules.player.asyncio.create_task")
+@patch("modules.player.asyncio.create_task", side_effect=lambda coro: coro.close())
 @patch("modules.player.asyncio.get_running_loop")
 @patch("modules.player.random.randint", return_value=5)
 @patch("modules.player.discord.FFmpegOpusAudio")
@@ -216,7 +216,7 @@ async def test_play_timeout_on_play(
 
 
 @pytest.mark.asyncio
-@patch("modules.player.asyncio.create_task")
+@patch("modules.player.asyncio.create_task", side_effect=lambda coro: coro.close())
 @patch("modules.player.asyncio.get_running_loop")
 @patch("modules.player.random.randint", return_value=5)
 @patch("modules.player.discord.FFmpegOpusAudio")


### PR DESCRIPTION
## Summary

- Creates `app/tests/` with 4 test files and shared fixtures covering all modules specified in `TESTING_SCHEMA.md`
- Adds `pytest`, `pytest-asyncio`, and `pytest-mock` to `app/pyproject.toml` dev dependencies
- Add makefile command to run tests via pytest

## What's tested

| File | Coverage |
|------|----------|
| `test_player_cog.py` | `cogs/Player.py` — `master_command` (5), `random` (6), `stop` (3) |
| `test_player_module.py` | `modules/player.py` — `_make_source` (3), `_maybe_send_media` (3), `Player.play` (9) |
| `test_helper_functions.py` | `modules/helper_functions.py` — format, dates, DB, ffmpeg (13) |
| `test_aliases.py` | `modules/aliases.py` — `Sound`, `SoundsInfo.getAliasInfo`, `update_sounds` (8) |

## Key design decisions

- `conftest.py` injects `sys.modules` stubs before any app import to prevent `AppConfig` (Redis + filesystem validation) and `SoundsInfo` (os.scandir) from running at collection time
- Discord command methods need `cmd.cog` set before calling — `make_cog()` injects this so tests can call commands naturally without a full bot setup
- `asyncio_mode = "auto"` so async tests need no decorator